### PR TITLE
Standardize API to Match JSON Marshal/Unmarshal API

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,7 +41,7 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/asmdecl:go_tool_library",
     ],
     visibility = ["//visibility:public"],
-    config = "nogo_config.json", 
+    config = "nogo_config.json",
 )
 
 workspace_binary(
@@ -53,15 +53,15 @@ go_library(
     name = "go_default_library",
     srcs = [
         "config.go",
-        "decode.go",
         "doc.go",
-        "encode.go",
         "hash_cache.go",
         "hash_tree_root.go",
         "helpers.go",
+        "marshal.go",
         "signing_root.go",
         "size.go",
         "ssz_utils_cache.go",
+        "unmarshal.go",
         "utils.go",
     ],
     importpath = "github.com/prysmaticlabs/go-ssz",
@@ -77,9 +77,9 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
-        "encode_decode_test.go",
         "hash_tree_root_test.go",
         "helpers_test.go",
+        "marshal_unmarshal_test.go",
         "signing_root_test.go",
     ],
     embed = [":go_default_library"],

--- a/README.md
+++ b/README.md
@@ -6,61 +6,26 @@ This package implements simple serialize algorithm specified in official Ethereu
 [![Documentation](https://godoc.org/github.com/prysmatic-labs/go-ssz?status.svg)](http://godoc.org/github.com/prysmatic-labs/go-ssz)
 [![codecov](https://codecov.io/gh/prysmaticlabs/go-ssz/branch/master/graph/badge.svg)](https://codecov.io/gh/prysmaticlabs/go-ssz)
 
-## Interface
-
-### Encodable
-A type is Encodable if it implements `EncodeSSZ` and `EncodeSSZSize` function.
-
-```go
-type Encodable interface {
-	EncodeSSZ(io.Writer) error
-	// Estimate the encoding size of the object without doing the actual encoding
-	EncodeSSZSize() (uint32, error)
-}
-```
-
-### Decodable
-A type is Decodable if it implements `DecodeSSZ()`.
-```go
-type Decodable interface {
-	DecodeSSZ(io.Reader) error
-}
-```
-
-### Hashable
-A type is Hashable if it implements `TreeHashSSZ()`.
-```go
-type Hashable interface {
-	TreeHashSSZ() ([32]byte, error)
-}
-```
-
 ## API
 
-### Encoding function
+Our simple serialize API is designed to match the popular JSON marshal/unmarshal API from the Go standard library
 
 ```go
-// Encode val and output the result into w.
-func Encode(w io.Writer, val interface{}) error
+// Marshal val and output the result.
+func Marshal(val interface{}) ([]byte, error)
 ```
 
 ```go
-// EncodeSize returns the target encoding size without doing the actual encoding.
-// This is an optional pass. You don't need to call this before the encoding unless you
-// want to know the output size first.
-func EncodeSize(val interface{}) (uint32, error)
+// Unmarshal data from input and output it into the object pointed by pointer val.
+func Unmarshal(input []byte, val interface{}) error
 ```
 
-### Decoding function
-```go
-// Decode data read from r and output it into the object pointed by pointer val.
-func Decode(r io.Reader, val interface{}) error
-```
+### Tree Hashing
 
-### Hashing function
 ```go
-// Tree-hash data into [32]byte
-func TreeHash(val interface{}) ([32]byte, error)
+// HashTreeRoot SSZ marshals a value and packs its serialized bytes into leaves of a Merkle trie -
+// then, it determines the Merkle root of the trie.
+func HashTreeRoot(val interface{}) ([32]byte, error)
 ````
 
 ## Usage
@@ -73,18 +38,6 @@ type exampleStruct1 struct {
 }
 ````
 
-You implement the `Encoding` interface for it:
-
-```go
-func (e *exampleStruct1) EncodeSSZ(w io.Writer) error {
-	return Encode(w, *e)
-}
-
-func (e *exampleStruct1) EncodeSSZSize() (uint32, error) {
-	return EncodeSize(*e)
-}
-```
-
 Now you can encode this object like this
 ```go
 e1 := &exampleStruct1{
@@ -96,15 +49,6 @@ if err = e1.EncodeSSZ(wBuf); err != nil {
     return fmt.Errorf("failed to encode: %v", err)
 }
 encoding := wBuf.Bytes() // encoding becomes [0 0 0 9 10 0 0 0 4 1 2 3 4]
-```
-
-You can also get the estimated encoding size
-```go
-var encodeSize uint32
-if encodeSize, err = e1.EncodeSSZSize(); err != nil {
-    return fmt.Errorf("failed to get encode size: %v", err)
-}
-// encodeSize becomes 13
 ```
 
 To calculate tree-hash of the object
@@ -145,4 +89,4 @@ if err = e2.DecodeSSZ(rBuf); err != nil {
 - slice
 - array
 - struct
-- pointer (nil pointer is not supported)
+- pointer

--- a/README.md
+++ b/README.md
@@ -40,48 +40,36 @@ type exampleStruct1 struct {
 
 Now you can encode this object like this
 ```go
-e1 := &exampleStruct1{
+e1 := exampleStruct1{
     Field1: 10,
     Field2: []byte{1, 2, 3, 4},
 }
-wBuf := new(bytes.Buffer)
-if err = e1.EncodeSSZ(wBuf); err != nil {
-    return fmt.Errorf("failed to encode: %v", err)
+encoded, err := Marshal(e1)
+if err != nil {
+    return fmt.Errorf("failed to marshal: %v", err)
 }
-encoding := wBuf.Bytes() // encoding becomes [0 0 0 9 10 0 0 0 4 1 2 3 4]
 ```
 
-To calculate tree-hash of the object
-```go
-var hash [32]byte
-if hash, err = e1.TreeHashSSZ(); err != nil {
-    return fmt.Errorf("failed to hash: %v", err)
-}
-// hash stores the hashing result
-```
-
-Similarly, you can implement the `Decodable` interface for this struct
+Similarly, you can unmarshal encoded bytes into its original form:
 
 ```go
-func (e *exampleStruct1) DecodeSSZ(r io.Reader) error {
-	return Decode(r, e)
+var e2 exampleStruct
+if err = Unmarshal(encoded, &e2); err != nil {
+    return fmt.Errorf("failed to unmarshal: %v", err)
 }
+reflect.DeepEqual(e1, e2) // Returns true as e2 now has the same content as e1.
 ```
 
-Now you can decode to create new struct
-
+To calculate tree-hash root of the object run:
 ```go
-e2 := new(exampleStruct1)
-rBuf := bytes.NewReader(encoding)
-if err = e2.DecodeSSZ(rBuf); err != nil {
-    return fmt.Errorf("failed to decode: %v", err)
+root, err := HashTreeRoot(e1)
+if err != nil {
+    return fmt.Errorf("failed to compute Merkle root: %v", err)
 }
-// e2 now has the same content as e1
 ```
-
-## Notes
 
 ### Supported data types
+- bool
 - uint8
 - uint16
 - uint32

--- a/hash_cache.go
+++ b/hash_cache.go
@@ -153,11 +153,11 @@ func makeSliceHasherCache(typ reflect.Type) (hasher, error) {
 	hasher := func(val reflect.Value) ([32]byte, error) {
 		hs, err := hashedEncoding(val)
 		if err != nil {
-			return [32]byte{}, fmt.Errorf("failed to encode element of slice/array: %v", err)
+			return [32]byte{}, fmt.Errorf("failed to marshal element of slice/array: %v", err)
 		}
 		exists, fetchedInfo, err := hashCache.RootByEncodedHash(hs)
 		if err != nil {
-			return [32]byte{}, fmt.Errorf("failed to encode element of slice/array: %v", err)
+			return [32]byte{}, fmt.Errorf("failed to marshal element of slice/array: %v", err)
 		}
 		var output [32]byte
 		if exists {
@@ -194,11 +194,11 @@ func makeStructHasherCache(typ reflect.Type) (hasher, error) {
 	hasher := func(val reflect.Value) ([32]byte, error) {
 		hs, err := hashedEncoding(val)
 		if err != nil {
-			return hs, fmt.Errorf("failed to encode element of slice/array: %v", err)
+			return hs, fmt.Errorf("failed to marshal element of slice/array: %v", err)
 		}
 		exists, fetchedInfo, err := hashCache.RootByEncodedHash(hs)
 		if err != nil {
-			return hs, fmt.Errorf("failed to encode element of slice/array: %v", err)
+			return hs, fmt.Errorf("failed to marshal element of slice/array: %v", err)
 		}
 		if exists {
 			return ToBytes32(fetchedInfo.MerkleRoot), nil

--- a/marshal_unmarshal_test.go
+++ b/marshal_unmarshal_test.go
@@ -1,7 +1,6 @@
 package ssz
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 )
@@ -12,7 +11,7 @@ type fork struct {
 	Epoch           uint64
 }
 
-func TestEncodeDecode(t *testing.T) {
+func TestMarshalUnmarshal(t *testing.T) {
 	forkExample := fork{
 		PreviousVersion: [4]byte{2, 3, 4, 1},
 		CurrentVersion:  [4]byte{5, 6, 7, 8},
@@ -63,11 +62,11 @@ func TestEncodeDecode(t *testing.T) {
 		{input: [][4]fork{{forkExample, forkExample, forkExample}}, ptr: new([][4]fork)},
 	}
 	for _, tt := range tests {
-		buffer := new(bytes.Buffer)
-		if err := Encode(buffer, tt.input); err != nil {
+		serializedItem, err := Marshal(tt.input)
+		if err != nil {
 			panic(err)
 		}
-		if err := Decode(buffer.Bytes(), tt.ptr); err != nil {
+		if err := Unmarshal(serializedItem, tt.ptr); err != nil {
 			t.Fatal(err)
 		}
 		output := reflect.ValueOf(tt.ptr)

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -7,102 +7,102 @@ import (
 	"reflect"
 )
 
-// decodeError is what gets reported to the decoder user in error case.
-type decodeError struct {
+// unmarshalError is what gets reported to the user in error case.
+type unmarshalError struct {
 	msg string
 	typ reflect.Type
 }
 
-func newDecodeError(msg string, typ reflect.Type) *decodeError {
-	return &decodeError{msg, typ}
+func newUnmarshalError(msg string, typ reflect.Type) *unmarshalError {
+	return &unmarshalError{msg, typ}
 }
 
-func (err *decodeError) Error() string {
-	return fmt.Sprintf("decode error: %s for output type %v", err.msg, err.typ)
+func (err *unmarshalError) Error() string {
+	return fmt.Sprintf("unmarshal error: %s for output type %v", err.msg, err.typ)
 }
 
-// Decode SSZ encoded data and output it into the object pointed by pointer val.
-func Decode(input []byte, val interface{}) error {
+// Unmarshal SSZ encoded data and output it into the object pointed by pointer val.
+func Unmarshal(input []byte, val interface{}) error {
 	if val == nil {
-		return newDecodeError("cannot decode into nil", nil)
+		return newUnmarshalError("cannot unmarshal into nil", nil)
 	}
 	rval := reflect.ValueOf(val)
 	rtyp := rval.Type()
-	// val must be a pointer, otherwise we refuse to decode
+	// val must be a pointer, otherwise we refuse to unmarshal
 	if rtyp.Kind() != reflect.Ptr {
-		return newDecodeError("can only decode into pointer target", rtyp)
+		return newUnmarshalError("can only unmarshal into pointer target", rtyp)
 	}
 	if rval.IsNil() {
-		return newDecodeError("cannot output to pointer of nil", rtyp)
+		return newUnmarshalError("cannot output to pointer of nil", rtyp)
 	}
 	sszUtils, err := cachedSSZUtils(rval.Elem().Type())
 	if err != nil {
-		return newDecodeError(fmt.Sprint(err), rval.Elem().Type())
+		return newUnmarshalError(fmt.Sprint(err), rval.Elem().Type())
 	}
-	if _, err = sszUtils.decoder(input, rval.Elem(), 0); err != nil {
-		return newDecodeError(fmt.Sprint(err), rval.Elem().Type())
+	if _, err = sszUtils.unmarshaler(input, rval.Elem(), 0); err != nil {
+		return newUnmarshalError(fmt.Sprint(err), rval.Elem().Type())
 	}
 	return nil
 }
 
-func makeDecoder(typ reflect.Type) (dec decoder, err error) {
+func makeUnmarshaler(typ reflect.Type) (dec unmarshaler, err error) {
 	kind := typ.Kind()
 	switch {
 	case kind == reflect.Bool:
-		return decodeBool, nil
+		return unmarshalBool, nil
 	case kind == reflect.Uint8:
-		return decodeUint8, nil
+		return unmarshalUint8, nil
 	case kind == reflect.Uint16:
-		return decodeUint16, nil
+		return unmarshalUint16, nil
 	case kind == reflect.Uint32:
-		return decodeUint32, nil
+		return unmarshalUint32, nil
 	case kind == reflect.Int32:
-		return decodeUint32, nil
+		return unmarshalUint32, nil
 	case kind == reflect.Uint64:
-		return decodeUint64, nil
+		return unmarshalUint64, nil
 	case kind == reflect.Slice && typ.Elem().Kind() == reflect.Uint8:
-		return makeByteSliceDecoder()
+		return makeByteSliceUnmarshaler()
 	case kind == reflect.Slice && isBasicType(typ.Elem().Kind()):
-		return makeBasicSliceDecoder(typ)
+		return makeBasicSliceUnmarshaler(typ)
 	case kind == reflect.Slice && isBasicTypeArray(typ.Elem(), typ.Elem().Kind()):
-		return makeBasicSliceDecoder(typ)
+		return makeBasicSliceUnmarshaler(typ)
 	case kind == reflect.Slice && isBasicTypeArray(typ.Elem(), typ.Elem().Kind()):
-		return makeBasicSliceDecoder(typ)
+		return makeBasicSliceUnmarshaler(typ)
 	case kind == reflect.Slice:
-		return makeCompositeSliceDecoder(typ)
+		return makeCompositeSliceUnmarshaler(typ)
 	case kind == reflect.Array && isBasicType(typ.Elem().Kind()):
-		return makeBasicArrayDecoder(typ)
+		return makeBasicArrayUnmarshaler(typ)
 	case kind == reflect.Array && isBasicTypeArray(typ.Elem(), typ.Elem().Kind()):
-		return makeBasicArrayDecoder(typ)
+		return makeBasicArrayUnmarshaler(typ)
 	case kind == reflect.Array:
-		return makeCompositeArrayDecoder(typ)
+		return makeCompositeArrayUnmarshaler(typ)
 	case kind == reflect.Struct:
-		return makeStructDecoder(typ)
+		return makeStructUnmarshaler(typ)
 	case kind == reflect.Ptr:
-		return makePtrDecoder(typ)
+		return makePtrUnmarshaler(typ)
 	default:
 		return nil, fmt.Errorf("type %v is not deserializable", typ)
 	}
 }
 
-func decodeBool(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
+func unmarshalBool(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
 	v := uint8(input[startOffset])
 	if v == 0 {
 		val.SetBool(false)
 	} else if v == 1 {
 		val.SetBool(true)
 	} else {
-		return 0, fmt.Errorf("expect 0 or 1 for decoding bool but got %d", v)
+		return 0, fmt.Errorf("expected 0 or 1 but received %d", v)
 	}
 	return startOffset + 1, nil
 }
 
-func decodeUint8(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
+func unmarshalUint8(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
 	val.SetUint(uint64(input[startOffset]))
 	return startOffset + 1, nil
 }
 
-func decodeUint16(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
+func unmarshalUint16(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
 	offset := startOffset + 2
 	buf := make([]byte, 2)
 	copy(buf, input[startOffset:offset])
@@ -110,7 +110,7 @@ func decodeUint16(input []byte, val reflect.Value, startOffset uint64) (uint64, 
 	return offset, nil
 }
 
-func decodeUint32(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
+func unmarshalUint32(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
 	offset := startOffset + 4
 	buf := make([]byte, 4)
 	copy(buf, input[startOffset:offset])
@@ -118,7 +118,7 @@ func decodeUint32(input []byte, val reflect.Value, startOffset uint64) (uint64, 
 	return offset, nil
 }
 
-func decodeUint64(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
+func unmarshalUint64(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
 	offset := startOffset + 8
 	buf := make([]byte, 8)
 	copy(buf, input[startOffset:offset])
@@ -126,29 +126,29 @@ func decodeUint64(input []byte, val reflect.Value, startOffset uint64) (uint64, 
 	return offset, nil
 }
 
-func makeByteSliceDecoder() (decoder, error) {
-	decoder := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
+func makeByteSliceUnmarshaler() (unmarshaler, error) {
+	unmarshaler := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
 		offset := startOffset + uint64(len(input))
 		val.SetBytes(input[startOffset:offset])
 		return offset, nil
 	}
-	return decoder, nil
+	return unmarshaler, nil
 }
 
-func makeBasicSliceDecoder(typ reflect.Type) (decoder, error) {
+func makeBasicSliceUnmarshaler(typ reflect.Type) (unmarshaler, error) {
 	elemSSZUtils, err := cachedSSZUtilsNoAcquireLock(typ.Elem())
 	if err != nil {
 		return nil, err
 	}
-	decoder := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
+	unmarshaler := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
 		newVal := reflect.MakeSlice(val.Type(), 1, 1)
 		reflect.Copy(newVal, val)
 		val.Set(newVal)
 
 		index := startOffset
-		index, err = elemSSZUtils.decoder(input, val.Index(0), index)
+		index, err = elemSSZUtils.unmarshaler(input, val.Index(0), index)
 		if err != nil {
-			return 0, fmt.Errorf("failed to decode element of slice: %v", err)
+			return 0, fmt.Errorf("failed to unmarshal element of slice: %v", err)
 		}
 		elementSize := index - startOffset
 		endOffset := uint64(len(input)) / elementSize
@@ -158,24 +158,24 @@ func makeBasicSliceDecoder(typ reflect.Type) (decoder, error) {
 		val.Set(newVal)
 		i := uint64(1)
 		for i < endOffset {
-			index, err = elemSSZUtils.decoder(input, val.Index(int(i)), index)
+			index, err = elemSSZUtils.unmarshaler(input, val.Index(int(i)), index)
 			if err != nil {
-				return 0, fmt.Errorf("failed to decode element of slice: %v", err)
+				return 0, fmt.Errorf("failed to unmarshal element of slice: %v", err)
 			}
 			i++
 		}
 		return index, nil
 	}
-	return decoder, nil
+	return unmarshaler, nil
 }
 
-func makeCompositeSliceDecoder(typ reflect.Type) (decoder, error) {
+func makeCompositeSliceUnmarshaler(typ reflect.Type) (unmarshaler, error) {
 	elemType := typ.Elem()
 	elemSSZUtils, err := cachedSSZUtilsNoAcquireLock(elemType)
 	if err != nil {
 		return nil, err
 	}
-	decoder := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
+	unmarshaler := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
 		// TODO: Limitation, creating a list of type pointers creates a list of nil values.
 		newVal := reflect.MakeSlice(typ, 1, 1)
 		reflect.Copy(newVal, val)
@@ -203,12 +203,12 @@ func makeCompositeSliceDecoder(typ reflect.Type) (decoder, error) {
 			if currentOffset > nextOffset {
 				return 0, errors.New("offsets must be increasing")
 			}
-			// We grow the slice's size to accommodate a new element being decoded.
+			// We grow the slice's size to accommodate a new element being unmarshald.
 			newVal := reflect.MakeSlice(typ, i+1, i+1)
 			reflect.Copy(newVal, val)
 			val.Set(newVal)
-			if _, err := elemSSZUtils.decoder(input[currentOffset:nextOffset], val.Index(i), 0); err != nil {
-				return 0, fmt.Errorf("failed to decode element of slice: %v", err)
+			if _, err := elemSSZUtils.unmarshaler(input[currentOffset:nextOffset], val.Index(i), 0); err != nil {
+				return 0, fmt.Errorf("failed to unmarshal element of slice: %v", err)
 			}
 			i++
 			currentIndex = nextIndex
@@ -216,38 +216,38 @@ func makeCompositeSliceDecoder(typ reflect.Type) (decoder, error) {
 		}
 		return currentIndex, nil
 	}
-	return decoder, nil
+	return unmarshaler, nil
 }
 
-func makeBasicArrayDecoder(typ reflect.Type) (decoder, error) {
+func makeBasicArrayUnmarshaler(typ reflect.Type) (unmarshaler, error) {
 	elemType := typ.Elem()
 	elemSSZUtils, err := cachedSSZUtilsNoAcquireLock(elemType)
 	if err != nil {
 		return nil, err
 	}
-	decoder := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
+	unmarshaler := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
 		i := 0
 		index := startOffset
 		size := val.Len()
 		for i < size {
-			index, err = elemSSZUtils.decoder(input, val.Index(i), index)
+			index, err = elemSSZUtils.unmarshaler(input, val.Index(i), index)
 			if err != nil {
-				return 0, fmt.Errorf("failed to decode element of array: %v", err)
+				return 0, fmt.Errorf("failed to unmarshal element of array: %v", err)
 			}
 			i++
 		}
 		return index, nil
 	}
-	return decoder, nil
+	return unmarshaler, nil
 }
 
-func makeCompositeArrayDecoder(typ reflect.Type) (decoder, error) {
+func makeCompositeArrayUnmarshaler(typ reflect.Type) (unmarshaler, error) {
 	elemType := typ.Elem()
 	elemSSZUtils, err := cachedSSZUtilsNoAcquireLock(elemType)
 	if err != nil {
 		return nil, err
 	}
-	decoder := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
+	unmarshaler := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
 		currentIndex := startOffset
 		nextIndex := currentIndex
 		offsetVal := input[startOffset : startOffset+uint64(BytesPerLengthOffset)]
@@ -271,8 +271,8 @@ func makeCompositeArrayDecoder(typ reflect.Type) (decoder, error) {
 			if currentOffset > nextOffset {
 				return 0, errors.New("offsets must be increasing")
 			}
-			if _, err := elemSSZUtils.decoder(input[currentOffset:nextOffset], val.Index(i), 0); err != nil {
-				return 0, fmt.Errorf("failed to decode element of slice: %v", err)
+			if _, err := elemSSZUtils.unmarshaler(input[currentOffset:nextOffset], val.Index(i), 0); err != nil {
+				return 0, fmt.Errorf("failed to unmarshal element of slice: %v", err)
 			}
 			i++
 			currentIndex = nextIndex
@@ -280,15 +280,15 @@ func makeCompositeArrayDecoder(typ reflect.Type) (decoder, error) {
 		}
 		return currentIndex, nil
 	}
-	return decoder, nil
+	return unmarshaler, nil
 }
 
-func makeStructDecoder(typ reflect.Type) (decoder, error) {
+func makeStructUnmarshaler(typ reflect.Type) (unmarshaler, error) {
 	fields, err := structFields(typ)
 	if err != nil {
 		return nil, err
 	}
-	decoder := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
+	unmarshaler := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
 		endOffset := uint64(len(input))
 		currentIndex := startOffset
 		nextIndex := currentIndex
@@ -322,7 +322,7 @@ func makeStructDecoder(typ reflect.Type) (decoder, error) {
 			fieldSize := fixedSizes[i]
 			if fieldSize > 0 {
 				nextIndex = currentIndex + fieldSize
-				if _, err := f.sszUtils.decoder(input[currentIndex:nextIndex], val.Field(i), 0); err != nil {
+				if _, err := f.sszUtils.unmarshaler(input[currentIndex:nextIndex], val.Field(i), 0); err != nil {
 					return 0, err
 				}
 				currentIndex = nextIndex
@@ -330,7 +330,7 @@ func makeStructDecoder(typ reflect.Type) (decoder, error) {
 			} else {
 				firstOff := offsets[offsetIndex]
 				nextOff := offsets[offsetIndex+1]
-				if _, err := f.sszUtils.decoder(input[firstOff:nextOff], val.Field(i), 0); err != nil {
+				if _, err := f.sszUtils.unmarshaler(input[firstOff:nextOff], val.Field(i), 0); err != nil {
 					return 0, err
 				}
 				offsetIndex++
@@ -339,21 +339,21 @@ func makeStructDecoder(typ reflect.Type) (decoder, error) {
 		}
 		return 0, nil
 	}
-	return decoder, nil
+	return unmarshaler, nil
 }
 
-func makePtrDecoder(typ reflect.Type) (decoder, error) {
+func makePtrUnmarshaler(typ reflect.Type) (unmarshaler, error) {
 	elemType := typ.Elem()
 	elemSSZUtils, err := cachedSSZUtilsNoAcquireLock(elemType)
 	if err != nil {
 		return nil, err
 	}
-	decoder := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
-		elemDecodeSize, err := elemSSZUtils.decoder(input, val.Elem(), startOffset)
+	unmarshaler := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
+		elemSize, err := elemSSZUtils.unmarshaler(input, val.Elem(), startOffset)
 		if err != nil {
-			return 0, fmt.Errorf("failed to decode to object pointed by pointer: %v", err)
+			return 0, fmt.Errorf("failed to unmarshal to object pointed by pointer: %v", err)
 		}
-		return elemDecodeSize, nil
+		return elemSize, nil
 	}
-	return decoder, nil
+	return unmarshaler, nil
 }


### PR DESCRIPTION
This PR standardizes our public functions to match the JSON Marshal/Unmarshal API from the Go standard library. This will allow for us to easily run JSON fuzz tests against our SSZ repository.