### PR TITLE
Allow for Slices/Arrays of Pointers & Nested Structs to Pass Round Trip Marshaling/Unmarshaling

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,5 +1,5 @@
 -----BEGIN PGP SIGNED MESSAGE-----
-Hash: SHA512
+hash: SHA512
 
 Contact: mailto:security@prysmaticlabs.com
 Encryption: openpgp4fpr:0AE0051D647BA3C1A917AF4072E33E4DF1A5036E

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,5 +1,5 @@
 -----BEGIN PGP SIGNED MESSAGE-----
-hash: SHA512
+Hash: SHA512
 
 Contact: mailto:security@prysmaticlabs.com
 Encryption: openpgp4fpr:0AE0051D647BA3C1A917AF4072E33E4DF1A5036E

--- a/hash_cache.go
+++ b/hash_cache.go
@@ -85,7 +85,7 @@ func (b *hashCacheS) TrieRootCached(val interface{}) ([32]byte, error) {
 	}
 	var paddedOutput [32]byte
 	if exists {
-		paddedOutput = ToBytes32(fetchedInfo.MerkleRoot)
+		paddedOutput = toBytes32(fetchedInfo.MerkleRoot)
 	} else {
 		sszUtils, err := cachedSSZUtils(rval.Type())
 		if err != nil {
@@ -117,7 +117,7 @@ func (b *hashCacheS) MerkleHashCached(byteSlice [][]byte) ([32]byte, error) {
 	}
 	mh := [32]byte{}
 	if exists {
-		mh = ToBytes32(fetchedInfo.MerkleRoot)
+		mh = toBytes32(fetchedInfo.MerkleRoot)
 	} else {
 		mh = merkleize(byteSlice)
 		mr := &root{
@@ -161,7 +161,7 @@ func makeSliceHasherCache(typ reflect.Type) (hasher, error) {
 		}
 		var output [32]byte
 		if exists {
-			output = ToBytes32(fetchedInfo.MerkleRoot)
+			output = toBytes32(fetchedInfo.MerkleRoot)
 		} else {
 			var elemHashList [][]byte
 			for i := 0; i < val.Len(); i++ {
@@ -201,7 +201,7 @@ func makeStructHasherCache(typ reflect.Type) (hasher, error) {
 			return hs, fmt.Errorf("failed to marshal element of slice/array: %v", err)
 		}
 		if exists {
-			return ToBytes32(fetchedInfo.MerkleRoot), nil
+			return toBytes32(fetchedInfo.MerkleRoot), nil
 		}
 		roots := [][]byte{}
 		for _, f := range fields {

--- a/hash_tree_root.go
+++ b/hash_tree_root.go
@@ -218,5 +218,5 @@ func hashedEncoding(val reflect.Value) ([32]byte, error) {
 	if err != nil {
 		return [32]byte{}, err
 	}
-	return Hash(encoding), nil
+	return hash(encoding), nil
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -83,8 +83,8 @@ func TestMerkleize_Identity(t *testing.T) {
 
 func TestMerkleize_OK(t *testing.T) {
 	chunk := make([]byte, BytesPerChunk)
-	secondLayerRoot := Hash(append(chunk, chunk...))
-	thirdLayerRoot := Hash(append(secondLayerRoot[:], secondLayerRoot[:]...))
+	secondLayerRoot := hash(append(chunk, chunk...))
+	thirdLayerRoot := hash(append(secondLayerRoot[:], secondLayerRoot[:]...))
 	tests := []struct {
 		name   string
 		input  [][]byte
@@ -93,7 +93,7 @@ func TestMerkleize_OK(t *testing.T) {
 		{
 			name:   "two elements should return the hash of their concatenation",
 			input:  [][]byte{make([]byte, BytesPerChunk), make([]byte, BytesPerChunk)},
-			output: Hash(make([]byte, BytesPerChunk*2)),
+			output: hash(make([]byte, BytesPerChunk*2)),
 		},
 		{
 			name:   "four chunks should return the Merkle root of a three layer trie",

--- a/marshal_unmarshal_test.go
+++ b/marshal_unmarshal_test.go
@@ -11,11 +11,22 @@ type fork struct {
 	Epoch           uint64
 }
 
+type nestedItem struct {
+	Field1 []uint64
+	Field2 *fork
+	Field3 [3]byte
+}
+
 func TestMarshalUnmarshal(t *testing.T) {
 	forkExample := fork{
 		PreviousVersion: [4]byte{2, 3, 4, 1},
 		CurrentVersion:  [4]byte{5, 6, 7, 8},
 		Epoch:           5,
+	}
+	nestedItemExample := nestedItem{
+		Field1: []uint64{1, 2, 3, 4},
+		Field2: &forkExample,
+		Field3: [3]byte{32, 33, 34},
 	}
 	tests := []struct {
 		input interface{}
@@ -60,6 +71,13 @@ func TestMarshalUnmarshal(t *testing.T) {
 		{input: [][3]uint64{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, ptr: new([][3]uint64)},
 		{input: [3][]uint64{{1, 2}, {4, 5, 6}, {7}}, ptr: new([3][]uint64)},
 		{input: [][4]fork{{forkExample, forkExample, forkExample}}, ptr: new([][4]fork)},
+		// Pointer-type test cases.
+		{input: &forkExample, ptr: new(fork)},
+		{input: &nestedItemExample, ptr: new(nestedItem)},
+		{input: []*fork{&forkExample, &forkExample}, ptr: new([]*fork)},
+		{input: []*nestedItem{&nestedItemExample, &nestedItemExample}, ptr: new([]*nestedItem)},
+		{input: [2]*nestedItem{&nestedItemExample, &nestedItemExample}, ptr: new([2]*nestedItem)},
+		{input: [2]*fork{&forkExample, &forkExample}, ptr: new([2]*fork)},
 	}
 	for _, tt := range tests {
 		serializedItem, err := Marshal(tt.input)

--- a/size.go
+++ b/size.go
@@ -101,6 +101,8 @@ func determineVariableSize(val reflect.Value, typ reflect.Type) uint64 {
 			}
 		}
 		return totalSize
+	case kind == reflect.Ptr:
+		return determineVariableSize(val.Elem(), val.Elem().Type())
 	default:
 		return 0
 	}

--- a/utils.go
+++ b/utils.go
@@ -2,17 +2,17 @@ package ssz
 
 import "crypto/sha256"
 
-// ToBytes32 is a convenience method for converting a byte slice to a fix
+// toBytes32 is a convenience method for converting a byte slice to a fix
 // sized 32 byte array. This method will truncate the input if it is larger
 // than 32 bytes.
-func ToBytes32(x []byte) [32]byte {
+func toBytes32(x []byte) [32]byte {
 	var y [32]byte
 	copy(y[:], x)
 	return y
 }
 
-// Hash defines a function that returns the sha256 hash of the data passed in.
-func Hash(data []byte) [32]byte {
+// hash defines a function that returns the sha256 hash of the data passed in.
+func hash(data []byte) [32]byte {
 	var hash [32]byte
 
 	h := sha256.New()


### PR DESCRIPTION
This PR includes some helper functions and modifications to allow complex data structures such as slices of struct pointers `[]*pb.Validator` to pass, as well as structs that have a complex, inner fields such as

```go
type Fork struct {
	PreviousVersion [4]byte
	CurrentVersion  [4]byte
	Epoch           uint64
}

type NestedItem struct {
	Field1 []uint64
	Field2 *Fork
	Field3 [3]byte
}
```