### PR TITLE
Return [32]byte{} When Nil Pointer

### DIFF
--- a/hash_tree_root.go
+++ b/hash_tree_root.go
@@ -194,7 +194,7 @@ func makePtrHasher(typ reflect.Type) (hasher, error) {
 	}
 	hasher := func(val reflect.Value) ([32]byte, error) {
 		if val.IsNil() {
-			return hashedEncoding(val)
+			return [32]byte{}, nil
 		}
 		return elemSSZUtils.hasher(val.Elem())
 	}


### PR DESCRIPTION
No description for this - simple PR that returns an empty byte array when a value is a nil pointer when computing hash tree root.