### PR TITLE
Support SSZ Size Tags in Struct Marshaling/Unmarshaling

### DIFF
--- a/hash_cache.go
+++ b/hash_cache.go
@@ -187,7 +187,7 @@ func makeSliceHasherCache(typ reflect.Type) (hasher, error) {
 }
 
 func makeStructHasherCache(typ reflect.Type) (hasher, error) {
-	fields, err := structFields(typ)
+	fields, err := marshalerStructFields(typ)
 	if err != nil {
 		return nil, err
 	}

--- a/hash_tree_root.go
+++ b/hash_tree_root.go
@@ -165,7 +165,7 @@ func makeCompositeArrayHasher(typ reflect.Type) (hasher, error) {
 }
 
 func makeStructHasher(typ reflect.Type) (hasher, error) {
-	fields, err := structFields(typ)
+	fields, err := marshalerStructFields(typ)
 	if err != nil {
 		return nil, err
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -191,7 +191,7 @@ func makeCompositeSliceMarshaler(typ reflect.Type) (marshaler, error) {
 }
 
 func makeStructMarshaler(typ reflect.Type) (marshaler, error) {
-	fields, err := structFields(typ)
+	fields, err := marshalerStructFields(typ)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +213,7 @@ func makeStructMarshaler(typ reflect.Type) (marshaler, error) {
 		for i, f := range fields {
 			if !isVariableSizeType(val.Field(i), f.typ) {
 				newVal := reflect.New(f.typ).Elem()
-                reflect.Copy(newVal.Slice(0, newVal.Len()), val.Field(i))
+				reflect.Copy(newVal.Slice(0, newVal.Len()), val.Field(i))
 				fixedIndex, err = f.sszUtils.marshaler(newVal, buf, fixedIndex)
 				if err != nil {
 					return 0, err

--- a/marshal.go
+++ b/marshal.go
@@ -212,9 +212,7 @@ func makeStructMarshaler(typ reflect.Type) (marshaler, error) {
 		var err error
 		for i, f := range fields {
 			if !isVariableSizeType(val.Field(i), f.typ) {
-				newVal := reflect.New(f.typ).Elem()
-				reflect.Copy(newVal.Slice(0, newVal.Len()), val.Field(i))
-				fixedIndex, err = f.sszUtils.marshaler(newVal, buf, fixedIndex)
+				fixedIndex, err = f.sszUtils.marshaler(val.Field(i), buf, fixedIndex)
 				if err != nil {
 					return 0, err
 				}

--- a/marshal_unmarshal_test.go
+++ b/marshal_unmarshal_test.go
@@ -18,77 +18,79 @@ type nestedItem struct {
 }
 
 type prysmState struct {
-	HeadRoot []byte `ssz:"size=32"`
-	ForkType []byte `ssz:"size=4"`
+	HeadRoot []uint64 `ssz:"size=32"`
+	ForkType []byte   `ssz:"size=4"`
+	Epoch    uint64
 }
 
 func TestMarshalUnmarshal(t *testing.T) {
-	//forkExample := fork{
-	//	PreviousVersion: [4]byte{2, 3, 4, 1},
-	//	CurrentVersion:  [4]byte{5, 6, 7, 8},
-	//	Epoch:           5,
-	//}
-	//nestedItemExample := nestedItem{
-	//	Field1: []uint64{1, 2, 3, 4},
-	//	Field2: &forkExample,
-	//	Field3: [3]byte{32, 33, 34},
-	//}
-	headRoot := [32]byte{3, 4, 5}
+	forkExample := fork{
+		PreviousVersion: [4]byte{2, 3, 4, 1},
+		CurrentVersion:  [4]byte{5, 6, 7, 8},
+		Epoch:           5,
+	}
+	nestedItemExample := nestedItem{
+		Field1: []uint64{1, 2, 3, 4},
+		Field2: &forkExample,
+		Field3: [3]byte{32, 33, 34},
+	}
+	headRoot := [32]uint64{3, 4, 5}
 	forkType := [4]byte{6, 7}
 	stateExample := prysmState{
 		HeadRoot: headRoot[:],
 		ForkType: forkType[:],
+		Epoch:    5,
 	}
 	tests := []struct {
 		input interface{}
 		ptr   interface{}
 	}{
 		// Bool test cases.
-		//{input: true, ptr: new(bool)},
-		//{input: false, ptr: new(bool)},
-		//// Uint8 test cases.
-		//{input: byte(1), ptr: new(byte)},
-		//{input: byte(0), ptr: new(byte)},
-		//// Uint16 test cases.
-		//{input: uint16(100), ptr: new(uint16)},
-		//{input: uint16(232), ptr: new(uint16)},
-		//// Uint32 test cases.
-		//{input: uint32(1), ptr: new(uint32)},
-		//{input: uint32(1029391), ptr: new(uint32)},
-		//// Uint64 test cases.
-		//{input: uint64(5), ptr: new(uint64)},
-		//{input: uint64(23929309), ptr: new(uint64)},
-		//// Byte slice, byte array test cases.
-		//{input: [8]byte{1, 2, 3, 4, 5, 6, 7, 8}, ptr: new([8]byte)},
-		//{input: []byte{9, 8, 9, 8}, ptr: new([]byte)},
-		//// Basic type array test cases.
-		//{input: [12]uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, ptr: new([12]uint64)},
-		//{input: [100]bool{true, false, true, true}, ptr: new([100]bool)},
-		//{input: [20]uint16{3, 4, 5}, ptr: new([20]uint16)},
-		//{input: [20]uint32{4, 5}, ptr: new([20]uint32)},
-		//{input: [20][2]uint32{{3, 4}, {5}, {8}, {9, 10}}, ptr: new([20][2]uint32)},
-		//// Basic type slice test cases.
-		//{input: []uint64{1, 2, 3}, ptr: new([]uint64)},
-		//{input: []bool{true, false, true, true, true}, ptr: new([]bool)},
-		//{input: []uint32{0, 0, 0}, ptr: new([]uint32)},
-		//{input: []uint32{92939, 232, 222}, ptr: new([]uint32)},
-		//// Struct decoding test cases.
-		//{input: forkExample, ptr: new(fork)},
-		//{input: forkExample, ptr: new(fork)},
-		//// Non-basic type slice/array test cases.
-		//{input: []fork{forkExample, forkExample}, ptr: new([]fork)},
-		//{input: [][]uint64{{4, 3, 2}, {1}, {0}}, ptr: new([][]uint64)},
-		//{input: [][][]uint64{{{1, 2}, {3}}, {{4, 5}}, {{0}}}, ptr: new([][][]uint64)},
-		//{input: [][3]uint64{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, ptr: new([][3]uint64)},
-		//{input: [3][]uint64{{1, 2}, {4, 5, 6}, {7}}, ptr: new([3][]uint64)},
-		//{input: [][4]fork{{forkExample, forkExample, forkExample}}, ptr: new([][4]fork)},
-		//// Pointer-type test cases.
-		//{input: &forkExample, ptr: new(fork)},
-		//{input: &nestedItemExample, ptr: new(nestedItem)},
-		//{input: []*fork{&forkExample, &forkExample}, ptr: new([]*fork)},
-		//{input: []*nestedItem{&nestedItemExample, &nestedItemExample}, ptr: new([]*nestedItem)},
-		//{input: [2]*nestedItem{&nestedItemExample, &nestedItemExample}, ptr: new([2]*nestedItem)},
-		//{input: [2]*fork{&forkExample, &forkExample}, ptr: new([2]*fork)},
+		{input: true, ptr: new(bool)},
+		{input: false, ptr: new(bool)},
+		// Uint8 test cases.
+		{input: byte(1), ptr: new(byte)},
+		{input: byte(0), ptr: new(byte)},
+		// Uint16 test cases.
+		{input: uint16(100), ptr: new(uint16)},
+		{input: uint16(232), ptr: new(uint16)},
+		// Uint32 test cases.
+		{input: uint32(1), ptr: new(uint32)},
+		{input: uint32(1029391), ptr: new(uint32)},
+		// Uint64 test cases.
+		{input: uint64(5), ptr: new(uint64)},
+		{input: uint64(23929309), ptr: new(uint64)},
+		// Byte slice, byte array test cases.
+		{input: [8]byte{1, 2, 3, 4, 5, 6, 7, 8}, ptr: new([8]byte)},
+		{input: []byte{9, 8, 9, 8}, ptr: new([]byte)},
+		// Basic type array test cases.
+		{input: [12]uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, ptr: new([12]uint64)},
+		{input: [100]bool{true, false, true, true}, ptr: new([100]bool)},
+		{input: [20]uint16{3, 4, 5}, ptr: new([20]uint16)},
+		{input: [20]uint32{4, 5}, ptr: new([20]uint32)},
+		{input: [20][2]uint32{{3, 4}, {5}, {8}, {9, 10}}, ptr: new([20][2]uint32)},
+		// Basic type slice test cases.
+		{input: []uint64{1, 2, 3}, ptr: new([]uint64)},
+		{input: []bool{true, false, true, true, true}, ptr: new([]bool)},
+		{input: []uint32{0, 0, 0}, ptr: new([]uint32)},
+		{input: []uint32{92939, 232, 222}, ptr: new([]uint32)},
+		// Struct decoding test cases.
+		{input: forkExample, ptr: new(fork)},
+		{input: forkExample, ptr: new(fork)},
+		// Non-basic type slice/array test cases.
+		{input: []fork{forkExample, forkExample}, ptr: new([]fork)},
+		{input: [][]uint64{{4, 3, 2}, {1}, {0}}, ptr: new([][]uint64)},
+		{input: [][][]uint64{{{1, 2}, {3}}, {{4, 5}}, {{0}}}, ptr: new([][][]uint64)},
+		{input: [][3]uint64{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, ptr: new([][3]uint64)},
+		{input: [3][]uint64{{1, 2}, {4, 5, 6}, {7}}, ptr: new([3][]uint64)},
+		{input: [][4]fork{{forkExample, forkExample, forkExample}}, ptr: new([][4]fork)},
+		// Pointer-type test cases.
+		{input: &forkExample, ptr: new(fork)},
+		{input: &nestedItemExample, ptr: new(nestedItem)},
+		{input: []*fork{&forkExample, &forkExample}, ptr: new([]*fork)},
+		{input: []*nestedItem{&nestedItemExample, &nestedItemExample}, ptr: new([]*nestedItem)},
+		{input: [2]*nestedItem{&nestedItemExample, &nestedItemExample}, ptr: new([2]*nestedItem)},
+		{input: [2]*fork{&forkExample, &forkExample}, ptr: new([2]*fork)},
 		{input: stateExample, ptr: new(prysmState)},
 	}
 	for _, tt := range tests {

--- a/marshal_unmarshal_test.go
+++ b/marshal_unmarshal_test.go
@@ -1,7 +1,6 @@
 package ssz
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 )
@@ -34,6 +33,12 @@ func TestMarshalUnmarshal(t *testing.T) {
 	//	Field2: &forkExample,
 	//	Field3: [3]byte{32, 33, 34},
 	//}
+	headRoot := [32]byte{3, 4, 5}
+	forkType := [4]byte{6, 7}
+	stateExample := prysmState{
+		HeadRoot: headRoot[:],
+		ForkType: forkType[:],
+	}
 	tests := []struct {
 		input interface{}
 		ptr   interface{}
@@ -84,14 +89,13 @@ func TestMarshalUnmarshal(t *testing.T) {
 		//{input: []*nestedItem{&nestedItemExample, &nestedItemExample}, ptr: new([]*nestedItem)},
 		//{input: [2]*nestedItem{&nestedItemExample, &nestedItemExample}, ptr: new([2]*nestedItem)},
 		//{input: [2]*fork{&forkExample, &forkExample}, ptr: new([2]*fork)},
-		{input: &prysmState{HeadRoot: []byte{3, 4, 5}, ForkType: []byte{6, 7}}, ptr: new(prysmState)},
+		{input: stateExample, ptr: new(prysmState)},
 	}
 	for _, tt := range tests {
 		serializedItem, err := Marshal(tt.input)
 		if err != nil {
 			panic(err)
 		}
-		fmt.Println(serializedItem)
 		if err := Unmarshal(serializedItem, tt.ptr); err != nil {
 			t.Fatal(err)
 		}

--- a/marshal_unmarshal_test.go
+++ b/marshal_unmarshal_test.go
@@ -1,6 +1,7 @@
 package ssz
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -17,73 +18,80 @@ type nestedItem struct {
 	Field3 [3]byte
 }
 
+type prysmState struct {
+	HeadRoot []byte `ssz:"size=32"`
+	ForkType []byte `ssz:"size=4"`
+}
+
 func TestMarshalUnmarshal(t *testing.T) {
-	forkExample := fork{
-		PreviousVersion: [4]byte{2, 3, 4, 1},
-		CurrentVersion:  [4]byte{5, 6, 7, 8},
-		Epoch:           5,
-	}
-	nestedItemExample := nestedItem{
-		Field1: []uint64{1, 2, 3, 4},
-		Field2: &forkExample,
-		Field3: [3]byte{32, 33, 34},
-	}
+	//forkExample := fork{
+	//	PreviousVersion: [4]byte{2, 3, 4, 1},
+	//	CurrentVersion:  [4]byte{5, 6, 7, 8},
+	//	Epoch:           5,
+	//}
+	//nestedItemExample := nestedItem{
+	//	Field1: []uint64{1, 2, 3, 4},
+	//	Field2: &forkExample,
+	//	Field3: [3]byte{32, 33, 34},
+	//}
 	tests := []struct {
 		input interface{}
 		ptr   interface{}
 	}{
 		// Bool test cases.
-		{input: true, ptr: new(bool)},
-		{input: false, ptr: new(bool)},
-		// Uint8 test cases.
-		{input: byte(1), ptr: new(byte)},
-		{input: byte(0), ptr: new(byte)},
-		// Uint16 test cases.
-		{input: uint16(100), ptr: new(uint16)},
-		{input: uint16(232), ptr: new(uint16)},
-		// Uint32 test cases.
-		{input: uint32(1), ptr: new(uint32)},
-		{input: uint32(1029391), ptr: new(uint32)},
-		// Uint64 test cases.
-		{input: uint64(5), ptr: new(uint64)},
-		{input: uint64(23929309), ptr: new(uint64)},
-		// Byte slice, byte array test cases.
-		{input: [8]byte{1, 2, 3, 4, 5, 6, 7, 8}, ptr: new([8]byte)},
-		{input: []byte{9, 8, 9, 8}, ptr: new([]byte)},
-		// Basic type array test cases.
-		{input: [12]uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, ptr: new([12]uint64)},
-		{input: [100]bool{true, false, true, true}, ptr: new([100]bool)},
-		{input: [20]uint16{3, 4, 5}, ptr: new([20]uint16)},
-		{input: [20]uint32{4, 5}, ptr: new([20]uint32)},
-		{input: [20][2]uint32{{3, 4}, {5}, {8}, {9, 10}}, ptr: new([20][2]uint32)},
-		// Basic type slice test cases.
-		{input: []uint64{1, 2, 3}, ptr: new([]uint64)},
-		{input: []bool{true, false, true, true, true}, ptr: new([]bool)},
-		{input: []uint32{0, 0, 0}, ptr: new([]uint32)},
-		{input: []uint32{92939, 232, 222}, ptr: new([]uint32)},
-		// Struct decoding test cases.
-		{input: forkExample, ptr: new(fork)},
-		{input: forkExample, ptr: new(fork)},
-		// Non-basic type slice/array test cases.
-		{input: []fork{forkExample, forkExample}, ptr: new([]fork)},
-		{input: [][]uint64{{4, 3, 2}, {1}, {0}}, ptr: new([][]uint64)},
-		{input: [][][]uint64{{{1, 2}, {3}}, {{4, 5}}, {{0}}}, ptr: new([][][]uint64)},
-		{input: [][3]uint64{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, ptr: new([][3]uint64)},
-		{input: [3][]uint64{{1, 2}, {4, 5, 6}, {7}}, ptr: new([3][]uint64)},
-		{input: [][4]fork{{forkExample, forkExample, forkExample}}, ptr: new([][4]fork)},
-		// Pointer-type test cases.
-		{input: &forkExample, ptr: new(fork)},
-		{input: &nestedItemExample, ptr: new(nestedItem)},
-		{input: []*fork{&forkExample, &forkExample}, ptr: new([]*fork)},
-		{input: []*nestedItem{&nestedItemExample, &nestedItemExample}, ptr: new([]*nestedItem)},
-		{input: [2]*nestedItem{&nestedItemExample, &nestedItemExample}, ptr: new([2]*nestedItem)},
-		{input: [2]*fork{&forkExample, &forkExample}, ptr: new([2]*fork)},
+		//{input: true, ptr: new(bool)},
+		//{input: false, ptr: new(bool)},
+		//// Uint8 test cases.
+		//{input: byte(1), ptr: new(byte)},
+		//{input: byte(0), ptr: new(byte)},
+		//// Uint16 test cases.
+		//{input: uint16(100), ptr: new(uint16)},
+		//{input: uint16(232), ptr: new(uint16)},
+		//// Uint32 test cases.
+		//{input: uint32(1), ptr: new(uint32)},
+		//{input: uint32(1029391), ptr: new(uint32)},
+		//// Uint64 test cases.
+		//{input: uint64(5), ptr: new(uint64)},
+		//{input: uint64(23929309), ptr: new(uint64)},
+		//// Byte slice, byte array test cases.
+		//{input: [8]byte{1, 2, 3, 4, 5, 6, 7, 8}, ptr: new([8]byte)},
+		//{input: []byte{9, 8, 9, 8}, ptr: new([]byte)},
+		//// Basic type array test cases.
+		//{input: [12]uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, ptr: new([12]uint64)},
+		//{input: [100]bool{true, false, true, true}, ptr: new([100]bool)},
+		//{input: [20]uint16{3, 4, 5}, ptr: new([20]uint16)},
+		//{input: [20]uint32{4, 5}, ptr: new([20]uint32)},
+		//{input: [20][2]uint32{{3, 4}, {5}, {8}, {9, 10}}, ptr: new([20][2]uint32)},
+		//// Basic type slice test cases.
+		//{input: []uint64{1, 2, 3}, ptr: new([]uint64)},
+		//{input: []bool{true, false, true, true, true}, ptr: new([]bool)},
+		//{input: []uint32{0, 0, 0}, ptr: new([]uint32)},
+		//{input: []uint32{92939, 232, 222}, ptr: new([]uint32)},
+		//// Struct decoding test cases.
+		//{input: forkExample, ptr: new(fork)},
+		//{input: forkExample, ptr: new(fork)},
+		//// Non-basic type slice/array test cases.
+		//{input: []fork{forkExample, forkExample}, ptr: new([]fork)},
+		//{input: [][]uint64{{4, 3, 2}, {1}, {0}}, ptr: new([][]uint64)},
+		//{input: [][][]uint64{{{1, 2}, {3}}, {{4, 5}}, {{0}}}, ptr: new([][][]uint64)},
+		//{input: [][3]uint64{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, ptr: new([][3]uint64)},
+		//{input: [3][]uint64{{1, 2}, {4, 5, 6}, {7}}, ptr: new([3][]uint64)},
+		//{input: [][4]fork{{forkExample, forkExample, forkExample}}, ptr: new([][4]fork)},
+		//// Pointer-type test cases.
+		//{input: &forkExample, ptr: new(fork)},
+		//{input: &nestedItemExample, ptr: new(nestedItem)},
+		//{input: []*fork{&forkExample, &forkExample}, ptr: new([]*fork)},
+		//{input: []*nestedItem{&nestedItemExample, &nestedItemExample}, ptr: new([]*nestedItem)},
+		//{input: [2]*nestedItem{&nestedItemExample, &nestedItemExample}, ptr: new([2]*nestedItem)},
+		//{input: [2]*fork{&forkExample, &forkExample}, ptr: new([2]*fork)},
+		{input: &prysmState{HeadRoot: []byte{3, 4, 5}, ForkType: []byte{6, 7}}, ptr: new(prysmState)},
 	}
 	for _, tt := range tests {
 		serializedItem, err := Marshal(tt.input)
 		if err != nil {
 			panic(err)
 		}
+		fmt.Println(serializedItem)
 		if err := Unmarshal(serializedItem, tt.ptr); err != nil {
 			t.Fatal(err)
 		}

--- a/ssz_utils_cache.go
+++ b/ssz_utils_cache.go
@@ -143,8 +143,8 @@ func unmarshalerStructFields(typ reflect.Type) (fields []field, err error) {
 }
 
 func sszTagSize(tag string) (int, error) {
-	sizeValue := strings.IndexRune(tag, '=')
-	size, err := strconv.Atoi(tag[sizeValue+1:])
+	sizeStartIndex := strings.IndexRune(tag, '=')
+	size, err := strconv.Atoi(tag[sizeStartIndex+1:])
 	if err != nil {
 		return 0, err
 	}

--- a/ssz_utils_cache.go
+++ b/ssz_utils_cache.go
@@ -3,6 +3,7 @@ package ssz
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -87,23 +88,16 @@ func generateSSZUtilsForType(typ reflect.Type) (utils *sszUtils, err error) {
 type field struct {
 	index    int
 	name     string
+	typ reflect.Type
 	sszUtils *sszUtils
 }
 
 // truncateLast removes the last value of a struct, usually the signature,
 // in order to hash only the data the signature field is intended to represent.
 func truncateLast(typ reflect.Type) (fields []field, err error) {
-	for i := 0; i < typ.NumField(); i++ {
-		f := typ.Field(i)
-		if strings.Contains(f.Name, "XXX") {
-			continue
-		}
-		utils, err := cachedSSZUtilsNoAcquireLock(f.Type)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get ssz utils: %v", err)
-		}
-		name := f.Name
-		fields = append(fields, field{i, name, utils})
+	fields, err = structFields(typ)
+	if err != nil {
+		return nil, err
 	}
 	return fields[:len(fields)-1], nil
 }
@@ -114,12 +108,37 @@ func structFields(typ reflect.Type) (fields []field, err error) {
 		if strings.Contains(f.Name, "XXX") {
 			continue
 		}
-		utils, err := cachedSSZUtilsNoAcquireLock(f.Type)
+		fType, err := fieldType(f)
+		if err != nil {
+			return nil, err
+		}
+		utils, err := cachedSSZUtilsNoAcquireLock(fType)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get ssz utils: %v", err)
 		}
 		name := f.Name
-		fields = append(fields, field{i, name, utils})
+		fields = append(fields, field{index: i, name: name, sszUtils: utils, typ: fType})
 	}
 	return fields, nil
+}
+
+func sszTagSize(tag string) (int, error) {
+	sizeValue := strings.IndexRune(tag, '=')
+	size, err := strconv.Atoi(tag[sizeValue+1:])
+	if err != nil {
+		return 0, err
+	}
+	return size, nil
+}
+
+func fieldType(field reflect.StructField) (reflect.Type, error) {
+	item, exists := field.Tag.Lookup("ssz")
+	if exists {
+		size, err := sszTagSize(item)
+		if err != nil {
+			return nil, err
+		}
+		return reflect.ArrayOf(size, field.Type.Elem()), nil
+	}
+    return field.Type, nil
 }

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -224,7 +224,7 @@ func makeBasicArrayUnmarshaler(typ reflect.Type) (unmarshaler, error) {
 	unmarshaler := func(input []byte, val reflect.Value, startOffset uint64) (uint64, error) {
 		i := 0
 		index := startOffset
-		size := val.Len()
+		size := typ.Len()
 		for i < size {
 			index, err = elemSSZUtils.unmarshaler(input, val.Index(i), index)
 			if err != nil {
@@ -283,7 +283,7 @@ func makeCompositeArrayUnmarshaler(typ reflect.Type) (unmarshaler, error) {
 }
 
 func makeStructUnmarshaler(typ reflect.Type) (unmarshaler, error) {
-	fields, err := structFields(typ)
+	fields, err := unmarshalerStructFields(typ)
 	if err != nil {
 		return nil, err
 	}
@@ -294,8 +294,8 @@ func makeStructUnmarshaler(typ reflect.Type) (unmarshaler, error) {
 		fixedSizes := make([]uint64, len(fields))
 
 		for i := 0; i < len(fixedSizes); i++ {
-			if !isVariableSizeType(val.Field(i), val.Field(i).Type()) {
-				fixedSz := determineFixedSize(val.Field(i), val.Field(i).Type())
+			if !isVariableSizeType(val.Field(i), fields[i].typ) {
+				fixedSz := determineFixedSize(val.Field(i), fields[i].typ)
 				if fixedSz > 0 {
 					fixedSizes[i] = fixedSz
 				}


### PR DESCRIPTION
This PR resolves #9.

This PR allows proper marshaling of structs with ssz size struct tags as:
```
type someStruct struct {
	HeadRoot []uint64 `ssz:"size=32"`
	ForkType []byte `ssz:"size=4"`
}
```
treating the slices in the struct as fixed-size elements when marshaling through SSZ. This is particularly important for us to run the spec yaml tests as well as use protobufs for SSZ as generated protos do not allow us to specify fixed size arrays in fields.