### PR TITLE
HashedEncoding not requiring reflect

### DIFF
--- a/hash_cache.go
+++ b/hash_cache.go
@@ -67,7 +67,7 @@ func (b *hashCacheS) RootByEncodedHash(h common.Hash) (bool, *root, error) {
 }
 
 func (b *hashCacheS) lookup(rval reflect.Value, hasher hasher) ([32]byte, error) {
-	hs, err := HashedEncoding(rval)
+	hs, err := HashedEncoding(rval.Interface())
 	if err != nil {
 		return [32]byte{}, newHashError(fmt.Sprint(err), rval.Type())
 	}

--- a/hash_cache_test.go
+++ b/hash_cache_test.go
@@ -3,7 +3,6 @@ package ssz
 import (
 	"bytes"
 	"log"
-	"reflect"
 	"testing"
 	"time"
 )
@@ -47,7 +46,7 @@ func TestCache_byHash(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hs, err := HashedEncoding(reflect.ValueOf(byteSl))
+	hs, err := HashedEncoding(byteSl)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/hash_tree_root.go
+++ b/hash_tree_root.go
@@ -229,8 +229,9 @@ func getEncoding(val reflect.Value) ([]byte, error) {
 }
 
 // HashedEncoding returns the hash of the encoded object.
-func HashedEncoding(val reflect.Value) ([32]byte, error) {
-	encoding, err := getEncoding(val)
+func HashedEncoding(val interface{}) ([32]byte, error) {
+	rval := reflect.ValueOf(val)
+	encoding, err := getEncoding(rval)
 	if err != nil {
 		return [32]byte{}, err
 	}


### PR DESCRIPTION
remove the need to use reflect library when calling HashedEncoding
HashedEncoding now receives (interface{}) 