### PR TITLE
fix DepositData Marshal size

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "marshal_unmarshal_test.go",
         "signing_root_test.go",
         "struct_utils_test.go",
+        "marshal_test.go",
     ],
     embed = [":go_default_library"],
 )

--- a/determine_size.go
+++ b/determine_size.go
@@ -2,7 +2,6 @@ package ssz
 
 import (
 	"reflect"
-	"strings"
 )
 
 func isBasicType(kind reflect.Kind) bool {
@@ -75,16 +74,12 @@ func determineFixedSize(val reflect.Value, typ reflect.Type) uint64 {
 		return num
 	case kind == reflect.Struct:
 		totalSize := uint64(0)
-		for i := 0; i < typ.NumField(); i++ {
-			f := typ.Field(i)
-			if strings.Contains(f.Name, "XXX") {
-				continue
-			}
-			fType, err := determineFieldType(f)
-			if err != nil {
-				return 0
-			}
-			totalSize += determineFixedSize(val.Field(i), fType)
+		fields, err := structFields(typ)
+		if err != nil {
+			return 0
+		}
+		for _, f := range fields {
+			totalSize += determineFixedSize(val.Field(f.index), f.typ)
 		}
 		return totalSize
 	case kind == reflect.Ptr:
@@ -112,17 +107,16 @@ func determineVariableSize(val reflect.Value, typ reflect.Type) uint64 {
 		return totalSize
 	case kind == reflect.Struct:
 		totalSize := uint64(0)
-		for i := 0; i < typ.NumField(); i++ {
-			f := typ.Field(i)
-			fType, err := determineFieldType(f)
-			if err != nil {
-				return 0
-			}
-			if isVariableSizeType(fType) {
-				varSize := determineVariableSize(val.Field(i), fType)
+		fields, err := structFields(typ)
+		if err != nil {
+			return 0
+		}
+		for _, f := range fields {
+			if isVariableSizeType(f.typ) {
+				varSize := determineVariableSize(val.Field(f.index), f.typ)
 				totalSize += varSize + BytesPerLengthOffset
 			} else {
-				varSize := determineFixedSize(val.Field(i), fType)
+				varSize := determineFixedSize(val.Field(f.index), f.typ)
 				totalSize += varSize
 			}
 		}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,0 +1,45 @@
+package ssz
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+)
+
+type testDepositData struct {
+	Pubkey                []byte   `protobuf:"bytes,1,opt,name=pubkey,proto3" json:"pubkey,omitempty" ssz-size:"48"`
+	WithdrawalCredentials []byte   `protobuf:"bytes,2,opt,name=withdrawal_credentials,json=withdrawalCredentials,proto3" json:"withdrawal_credentials,omitempty" ssz-size:"32"`
+	Amount                uint64   `protobuf:"varint,3,opt,name=amount,proto3" json:"amount,omitempty"`
+	Signature             []byte   `protobuf:"bytes,4,opt,name=signature,proto3" json:"signature,omitempty" ssz-size:"96"`
+	XXX_NoUnkeyedLiteral  struct{} `json:"-"`
+	XXX_unrecognized      []byte   `json:"-"`
+	XXX_sizecache         int32    `json:"-"`
+}
+
+func TestMarshalDepositDataLen(t *testing.T) {
+	expectedResult, err := hex.DecodeString("b334e2fce27e6ebeaba7bbb9ca112c7f6acf5e863b22db3eec99458ddb1d5ac1a05f177590ae5257385a3bb7573405c60055dce78f09d5867624ec74bb486e64e15e6335537e926917fffd7c4d8f94900040597307000000982f0411aa3802331ecdcee8e1e39d14cf53d878bc4ca713b4d21311454f2a9c277bf6a27daa63c01c1e017eb355ed2f1928cd936ae37feee6cd8b339c92739d607fa77dea7bb98092f2c61c6d5df0aa4850614801eece31befd9f217235d353")
+	if err != nil {
+		t.Fatalf("Cannot read expected result: %v", err)
+	}
+	testStruct := &testDepositData{
+		Pubkey:                expectedResult[0:48],
+		WithdrawalCredentials: expectedResult[48 : 48+32],
+		Amount:                binary.LittleEndian.Uint64(expectedResult[48+32 : 48+32+8]),
+		Signature:             expectedResult[48+32+8 : 48+32+8+96],
+	}
+
+	serializedData, err := Marshal(testStruct)
+	if err != nil {
+		t.Fatalf("Cannot marshal data: %v", err)
+	}
+	if len(serializedData) != 184 {
+		t.Fatalf("invalid result len: %v", len(serializedData))
+	}
+	if !bytes.Equal(serializedData, expectedResult) {
+		t.Fatalf(`invalid marshal result
+			result  : %#x
+			expected: %#x
+		`, serializedData, expectedResult)
+	}
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -12,9 +12,9 @@ type testDepositData struct {
 	WithdrawalCredentials []byte   `protobuf:"bytes,2,opt,name=withdrawal_credentials,json=withdrawalCredentials,proto3" json:"withdrawal_credentials,omitempty" ssz-size:"32"`
 	Amount                uint64   `protobuf:"varint,3,opt,name=amount,proto3" json:"amount,omitempty"`
 	Signature             []byte   `protobuf:"bytes,4,opt,name=signature,proto3" json:"signature,omitempty" ssz-size:"96"`
-	XXX_NoUnkeyedLiteral  struct{} `json:"-"`
-	XXX_unrecognized      []byte   `json:"-"`
-	XXX_sizecache         int32    `json:"-"`
+	XXXNoUnkeyedLiteral   struct{} `json:"-"`
+	XXXunrecognized       []byte   `json:"-"`
+	XXXsizecache          int32    `json:"-"`
 }
 
 func TestMarshalDepositDataLen(t *testing.T) {


### PR DESCRIPTION
This PR fixs a sizing error for variable size structs with XXX field.

Example, if I call `bazel run //validator -- accounts create --keystore-path=/data --password=changeme` then get result: 0xb334e2f........f353**00000000**.
Last 8 bytes are redundant, and include in result because DepositData struct has an int32 field XXX_sizecache.