### PR TITLE
Remove useless check

### DIFF
--- a/hash_cache.go
+++ b/hash_cache.go
@@ -129,13 +129,11 @@ func generateCacheKey(v reflect.Value, marshaler marshaler, maxCapacity uint64) 
 			return nil, err
 		}
 	} else {
-		if v.Kind() != reflect.Struct || (v.Kind() == reflect.Ptr && !v.IsNil()) {
-			buf = make([]byte, determineSize(v))
-			if _, err := marshaler(v, buf, 0); err != nil {
-				return nil, err
-			}
-			binary.LittleEndian.PutUint64(encodedLength, uint64(len(buf)))
+		buf = make([]byte, determineSize(v))
+		if _, err := marshaler(v, buf, 0); err != nil {
+			return nil, err
 		}
+		binary.LittleEndian.PutUint64(encodedLength, uint64(len(buf)))
 		buf = append(buf, []byte(v.Type().String())...)
 	}
 	lengthMetadata := append(encodedCapacity, encodedLength...)


### PR DESCRIPTION
The second check wasn't needed, it always evaluate to true.