### PR TITLE
Few optimizations

### DIFF
--- a/hash_cache.go
+++ b/hash_cache.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 	"reflect"
 	"time"
 
@@ -81,7 +80,8 @@ func (b *hashCacheS) lookup(
 	}
 	// We take the hash of the generated cache key.
 	h, _ := highwayhash.New(make([]byte, 32))
-	if _, err := io.Copy(h, bytes.NewBuffer(cacheKey)); err != nil {
+
+	if _, err := h.Write(cacheKey); err != nil {
 		return [32]byte{}, err
 	}
 	hs := h.Sum(nil)

--- a/hash_cache_test.go
+++ b/hash_cache_test.go
@@ -2,7 +2,6 @@ package ssz
 
 import (
 	"bytes"
-	"io"
 	"reflect"
 	"testing"
 	"time"
@@ -58,7 +57,7 @@ func TestCache_byHash(t *testing.T) {
 		t.Fatal(err)
 	}
 	h, _ := highwayhash.New(make([]byte, 32))
-	if _, err := io.Copy(h, bytes.NewBuffer(k)); err != nil {
+	if _, err := h.Write(k); err != nil {
 		t.Fatal(err)
 	}
 	// We take the hash of the generate cache key.

--- a/helpers.go
+++ b/helpers.go
@@ -177,15 +177,5 @@ func toBytes32(x []byte) [32]byte {
 
 // hash defines a function that returns the sha256 hash of the data passed in.
 func hash(data []byte) [32]byte {
-	var hash [32]byte
-
-	h := sha256.New()
-	// The hash interface never returns an error, for that reason
-	// we are not handling the error below. For reference, it is
-	// stated here https://golang.org/pkg/hash/#Hash
-	// #nosec G104
-	h.Write(data)
-	h.Sum(hash[:0])
-
-	return hash
+	return sha256.Sum256(data)
 }

--- a/helpers.go
+++ b/helpers.go
@@ -2,10 +2,11 @@ package ssz
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"fmt"
 	"math"
 	"reflect"
+
+	"github.com/minio/sha256-simd"
 )
 
 var (

--- a/marshal.go
+++ b/marshal.go
@@ -149,8 +149,13 @@ func marshalByteSlice(val reflect.Value, buf []byte, startOffset uint64) (uint64
 
 func marshalByteArray(val reflect.Value, buf []byte, startOffset uint64) (uint64, error) {
 	rawBytes := make([]byte, val.Len())
-	for i := 0; i < val.Len(); i++ {
-		rawBytes[i] = uint8(val.Index(i).Uint())
+	switch v := val.Interface().(type) {
+	case []uint8:
+		copy(rawBytes, v)
+	default:
+		for i := 0; i < val.Len(); i++ {
+			rawBytes[i] = uint8(val.Index(i).Uint())
+		}
 	}
 	copy(buf[startOffset:startOffset+uint64(len(rawBytes))], rawBytes)
 	return startOffset + uint64(len(rawBytes)), nil

--- a/marshal.go
+++ b/marshal.go
@@ -96,7 +96,7 @@ func makeMarshaler(typ reflect.Type) (marshaler, error) {
 }
 
 func marshalBool(val reflect.Value, buf []byte, startOffset uint64) (uint64, error) {
-	if val.Bool() {
+	if val.Interface().(bool) {
 		buf[startOffset] = uint8(1)
 	} else {
 		buf[startOffset] = uint8(0)
@@ -105,51 +105,41 @@ func marshalBool(val reflect.Value, buf []byte, startOffset uint64) (uint64, err
 }
 
 func marshalUint8(val reflect.Value, buf []byte, startOffset uint64) (uint64, error) {
-	v := val.Uint()
-	buf[startOffset] = uint8(v)
+	buf[startOffset] = val.Interface().(uint8)
 	return startOffset + 1, nil
 }
 
 func marshalUint16(val reflect.Value, buf []byte, startOffset uint64) (uint64, error) {
-	v := val.Uint()
-	b := make([]byte, 2)
-	binary.LittleEndian.PutUint16(b, uint16(v))
-	copy(buf[startOffset:startOffset+2], b)
+	binary.LittleEndian.PutUint16(buf[startOffset:], val.Interface().(uint16))
 	return startOffset + 2, nil
 }
 
 func marshalUint32(val reflect.Value, buf []byte, startOffset uint64) (uint64, error) {
-	v := val.Uint()
-	b := make([]byte, 4)
-	binary.LittleEndian.PutUint32(b, uint32(v))
-	copy(buf[startOffset:startOffset+4], b)
+	binary.LittleEndian.PutUint32(buf[startOffset:], val.Interface().(uint32))
 	return startOffset + 4, nil
 }
 
 func marshalUint64(val reflect.Value, buf []byte, startOffset uint64) (uint64, error) {
-	v := val.Uint()
-	b := make([]byte, 8)
-	binary.LittleEndian.PutUint64(b, uint64(v))
-	copy(buf[startOffset:startOffset+8], b)
+	binary.LittleEndian.PutUint64(buf[startOffset:], val.Interface().(uint64))
 	return startOffset + 8, nil
 }
 
 func marshalByteSlice(val reflect.Value, buf []byte, startOffset uint64) (uint64, error) {
-	if _, ok := val.Interface().(bitfield.Bitfield); ok {
-		newVal := reflect.New(reflect.TypeOf([]byte{})).Elem()
-		newVal.Set(val)
-		newSlice := newVal.Interface().([]byte)
-		copy(buf[startOffset:startOffset+uint64(val.Len())], newSlice)
-		return startOffset + uint64(len(newSlice)), nil
+	if bits, ok := val.Interface().(bitfield.Bitlist); ok {
+		copy(buf[startOffset:], bits[:])
+		return startOffset + uint64(len(bits)), nil
 	}
-	slice := val.Slice(0, val.Len()).Interface().([]byte)
-	copy(buf[startOffset:startOffset+uint64(len(slice))], slice)
-	return startOffset + uint64(val.Len()), nil
+	v := val.Interface().([]byte)
+	copy(buf[startOffset:], v)
+	return startOffset + uint64(len(v)), nil
 }
 
 func marshalByteArray(val reflect.Value, buf []byte, startOffset uint64) (uint64, error) {
 	switch v := val.Interface().(type) {
 	case []uint8:
+		copy(buf[startOffset:], v)
+		return startOffset + uint64(len(v)), nil
+	case bitfield.Bitvector4:
 		copy(buf[startOffset:], v)
 		return startOffset + uint64(len(v)), nil
 	default:

--- a/marshal.go
+++ b/marshal.go
@@ -148,17 +148,16 @@ func marshalByteSlice(val reflect.Value, buf []byte, startOffset uint64) (uint64
 }
 
 func marshalByteArray(val reflect.Value, buf []byte, startOffset uint64) (uint64, error) {
-	rawBytes := make([]byte, val.Len())
 	switch v := val.Interface().(type) {
 	case []uint8:
-		copy(rawBytes, v)
+		copy(buf[startOffset:], v)
+		return startOffset + uint64(len(v)), nil
 	default:
 		for i := 0; i < val.Len(); i++ {
-			rawBytes[i] = uint8(val.Index(i).Uint())
+			buf[int(startOffset)+i] = uint8(val.Index(i).Uint())
 		}
+		return startOffset + uint64(val.Len()), nil
 	}
-	copy(buf[startOffset:startOffset+uint64(len(rawBytes))], rawBytes)
-	return startOffset + uint64(len(rawBytes)), nil
 }
 
 func makeBasicSliceMarshaler(typ reflect.Type) (marshaler, error) {


### PR DESCRIPTION
Before:
```
2019/08/02 12:27:01 324.9995ms to unmarshal
2019/08/02 12:27:01 85.0004ms to marshal
2019/08/02 12:27:01 profile: cpu profiling enabled, Z:\Temp\profile279911603\cpu.pprof
2019/08/02 12:27:02 466.1326ms hash tree root
2019/08/02 12:27:02 90.9946ms subsequent hash tree root
2019/08/02 12:27:02 profile: cpu profiling disabled, Z:\Temp\profile279911603\cpu.pprof
```

After:
```
2019/08/02 12:27:11 319.9992ms to unmarshal
2019/08/02 12:27:11 38.0001ms to marshal
2019/08/02 12:27:11 profile: cpu profiling enabled, Z:\Temp\profile562274255\cpu.pprof
2019/08/02 12:27:11 252.9953ms hash tree root
2019/08/02 12:27:11 44.0049ms subsequent hash tree root
2019/08/02 12:27:12 profile: cpu profiling disabled, Z:\Temp\profile562274255\cpu.pprof
```