### PR TITLE
Additional coverage; catch a panic

### DIFF
--- a/ssz.go
+++ b/ssz.go
@@ -127,7 +127,7 @@ func HashTreeRoot(val interface{}) ([32]byte, error) {
 	rval := reflect.ValueOf(val)
 	factory, err := types.SSZFactory(rval, rval.Type())
 	if err != nil {
-		return [32]byte{}, errors.Wrapf(err, "could generate tree hasher for type: %v", rval.Type())
+		return [32]byte{}, errors.Wrapf(err, "could not generate tree hasher for type: %v", rval.Type())
 	}
 	return factory.Root(rval, rval.Type(), 0)
 }
@@ -151,7 +151,7 @@ func HashTreeRootWithCapacity(val interface{}, maxCapacity uint64) ([32]byte, er
 	}
 	factory, err := types.SSZFactory(rval, rval.Type())
 	if err != nil {
-		return [32]byte{}, errors.Wrapf(err, "could generate tree hasher for type: %v", rval.Type())
+		return [32]byte{}, errors.Wrapf(err, "could not generate tree hasher for type: %v", rval.Type())
 	}
 	return factory.Root(rval, rval.Type(), maxCapacity)
 }
@@ -160,6 +160,9 @@ func HashTreeRootWithCapacity(val interface{}, maxCapacity uint64) ([32]byte, er
 // and returns its tree hash. This is done because the last property
 // usually contains the signature that which this data is the root for.
 func SigningRoot(val interface{}) ([32]byte, error) {
+	if val == nil {
+		return [32]byte{}, errors.New("value cannot be nil")
+	}
 	valObj := reflect.ValueOf(val)
 	if valObj.Type().Kind() == reflect.Ptr {
 		if valObj.IsNil() {

--- a/ssz_test.go
+++ b/ssz_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 type fork struct {
@@ -40,6 +42,225 @@ func TestPartialDataMarshalUnmarshal(t *testing.T) {
 	dec := &block{}
 	if err := Unmarshal(enc, dec); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestMarshal(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  interface{}
+		output []byte
+		err    error
+	}{
+		{
+			name: "Nil",
+			err:  errors.New("untyped-value nil cannot be marshaled"),
+		},
+		{
+			name:  "Unsupported",
+			input: complex(1, 1),
+			err:   errors.New("unsupported kind: complex128"),
+		},
+		{
+			name:  "UnsupportedPointer",
+			input: &[]complex128{complex(1, 1), complex(1, 1)},
+			err:   errors.New("failed to marshal for type: []complex128: unsupported kind: complex128"),
+		},
+		{
+			name:  "UnsupportedStructElement",
+			input: struct{ Foo complex128 }{complex(1, 1)},
+			err:   errors.New("failed to marshal for type: struct { Foo complex128 }: unsupported kind: complex128"),
+		},
+		{
+			name:   "Simple",
+			input:  struct{ Foo uint32 }{12345},
+			output: []byte{0x39, 0x30, 0x00, 0x00},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output, err := Marshal(test.input)
+			if test.err == nil {
+				if err != nil {
+					t.Fatalf("unexpected error %v", err)
+				}
+				if bytes.Compare(test.output, output) != 0 {
+					t.Errorf("incorrect output: expected %v; received %v", test.output, output)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("missing expected error %v", test.err)
+				}
+				if test.err.Error() != err.Error() {
+					t.Errorf("incorrect error: expected %v; received %v", test.err, err)
+				}
+			}
+		})
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []byte
+		output interface{}
+		err    error
+	}{
+		{
+			name: "Nil",
+			err:  errors.New("cannot unmarshal into untyped, nil value"),
+		},
+		{
+			name:   "NotPointer",
+			input:  []byte{0x00, 0x00, 0x00, 0x00},
+			output: "",
+			err:    errors.New("can only unmarshal into a pointer target"),
+		},
+		{
+			name:   "OutputNotSupported",
+			input:  []byte{0x00, 0x00, 0x00, 0x00},
+			output: &struct{ Foo complex128 }{complex(1, 1)},
+			err:    errors.New("could not unmarshal input into type: struct { Foo complex128 }: unsupported kind: complex128"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := Unmarshal(test.input, test.output)
+			if test.err == nil {
+				if err != nil {
+					t.Errorf("unexpected error %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("missing expected error %v", test.err)
+				}
+				if test.err.Error() != err.Error() {
+					t.Errorf("unexpected error value %v (expected %v)", err, test.err)
+				}
+			}
+		})
+	}
+}
+
+func TestHashTreeRoot(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  interface{}
+		output [32]byte
+		err    error
+	}{
+		{
+			name: "Nil",
+			err:  errors.New("untyped nil is not supported"),
+		},
+		{
+			name:  "UnsupportedKind",
+			input: complex(1, 1),
+			err:   errors.New("could not generate tree hasher for type: complex128: unsupported kind: complex128"),
+		},
+		{
+			name:  "NoInput",
+			input: &struct{ Foo complex128 }{},
+			err:   errors.New("unsupported kind: complex128"),
+		},
+		{
+			name: "Valid",
+			input: fork{
+				PreviousVersion: [4]byte{0x9f, 0x41, 0xbd, 0x5b},
+				CurrentVersion:  [4]byte{0xcb, 0xb0, 0xf1, 0xd7},
+				Epoch:           11971467576204192310,
+			},
+			output: [32]byte{0x3a, 0xd1, 0x26, 0x4c, 0x33, 0xbc, 0x66, 0xb4, 0x3a, 0x49, 0xb1, 0x25, 0x8b, 0x88, 0xf3, 0x4b, 0x8d, 0xbf, 0xa1, 0x64, 0x9f, 0x17, 0xe6, 0xdf, 0x55, 0x0f, 0x58, 0x96, 0x50, 0xd3, 0x49, 0x92},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output, err := HashTreeRoot(test.input)
+			if test.err == nil {
+				if err != nil {
+					t.Errorf("unexpected error %v", err)
+				}
+				if bytes.Compare(test.output[:], output[:]) != 0 {
+					t.Errorf("incorrect output: expected %v; received %v", test.output, output)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("missing expected error %v", test.err)
+				}
+				if test.err.Error() != err.Error() {
+					t.Errorf("incorrect error: expected %v; received %v", test.err, err)
+				}
+			}
+		})
+	}
+}
+
+func TestHashTreeRootWithCapacity(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       interface{}
+		maxCapacity uint64
+		output      [32]byte
+		err         error
+	}{
+		{
+			name: "Nil",
+			err:  errors.New("untyped nil is not supported"),
+		},
+		{
+			name:  "NotSlice",
+			input: "foo",
+			err:   errors.New("expected slice-kind input, received string"),
+		},
+		{
+			name:  "InvalidSlice1",
+			input: []complex128{complex(1, 1)},
+			err:   errors.New("unsupported kind: complex128"),
+		},
+		{
+			name:  "InvalidSlice2",
+			input: []struct{ Foo complex128 }{{Foo: complex(1, 1)}},
+			err:   errors.New("unsupported kind: complex128"),
+		},
+		{
+			name:   "NoInput",
+			input:  []uint32{},
+			output: [32]byte{0xf5, 0xa5, 0xfd, 0x42, 0xd1, 0x6a, 0x20, 0x30, 0x27, 0x98, 0xef, 0x6e, 0xd3, 0x09, 0x97, 0x9b, 0x43, 0x00, 0x3d, 0x23, 0x20, 0xd9, 0xf0, 0xe8, 0xea, 0x98, 0x31, 0xa9, 0x27, 0x59, 0xfb, 0x4b},
+		},
+		{
+			name: "Valid",
+			input: []fork{fork{
+				PreviousVersion: [4]byte{0x9f, 0x41, 0xbd, 0x5b},
+				CurrentVersion:  [4]byte{0xcb, 0xb0, 0xf1, 0xd7},
+				Epoch:           11971467576204192310,
+			}},
+			maxCapacity: 100,
+			output:      [32]byte{0x5c, 0xa4, 0xd8, 0xbf, 0x17, 0xb9, 0x53, 0x6d, 0x69, 0x56, 0xee, 0x48, 0xfa, 0x3d, 0xc6, 0x91, 0xe3, 0x52, 0x48, 0xbd, 0x09, 0xb2, 0x9b, 0x1b, 0x5b, 0xa4, 0x5a, 0x0e, 0xd5, 0xda, 0xe0, 0xd9},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output, err := HashTreeRootWithCapacity(test.input, test.maxCapacity)
+			if test.err == nil {
+				if err != nil {
+					t.Fatalf("unexpected error %v", err)
+				}
+				if bytes.Compare(test.output[:], output[:]) != 0 {
+					t.Errorf("incorrect output: expected %v; received %v", test.output, output)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("missing expected error %v", test.err)
+				}
+				if test.err.Error() != err.Error() {
+					t.Errorf("incorrect error: expected %v; received %v", test.err, err)
+				}
+			}
+		})
 	}
 }
 
@@ -97,37 +318,6 @@ func TestEmptyDataUnmarshal(t *testing.T) {
 	msg := &simpleProtoMessage{}
 	if err := Unmarshal([]byte{}, msg); err == nil {
 		t.Error("Expected unmarshal to fail when attempting to unmarshal from an empty byte slice")
-	}
-}
-
-func TestHashTreeRoot(t *testing.T) {
-	var currentVersion [4]byte
-	var previousVersion [4]byte
-	prev, err := hex.DecodeString("9f41bd5b")
-	if err != nil {
-		t.Fatal(err)
-	}
-	copy(previousVersion[:], prev)
-	curr, err := hex.DecodeString("cbb0f1d7")
-	if err != nil {
-		t.Fatal(err)
-	}
-	copy(currentVersion[:], curr)
-	forkItem := fork{
-		PreviousVersion: previousVersion,
-		CurrentVersion:  currentVersion,
-		Epoch:           11971467576204192310,
-	}
-	root, err := HashTreeRoot(forkItem)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want, err := hex.DecodeString("3ad1264c33bc66b43a49b1258b88f34b8dbfa1649f17e6df550f589650d34992")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(root[:], want) {
-		t.Errorf("want %#x, HashTreeRoot() = %#x", want, root)
 	}
 }
 
@@ -213,6 +403,7 @@ func TestSigningRoot(t *testing.T) {
 	type signingRootTest struct {
 		Val1 interface{}
 		Val2 interface{}
+		Err  error
 	}
 	type truncateLastCase struct {
 		Slot           uint64
@@ -266,20 +457,35 @@ func TestSigningRoot(t *testing.T) {
 				TruncatedField: []byte("SHOULDNT"),
 			},
 		},
+		{
+			Val1: nil,
+			Err:  errors.New("value cannot be nil"),
+			Val2: nil,
+		},
 	}
 
 	for i, test := range signingRootTests {
 		output1, err := SigningRoot(test.Val1)
-		if err != nil {
-			t.Errorf("could not get the signing root of test %d, value 1 %v", i, err)
-		}
-		output2, err := SigningRoot(test.Val2)
-		if err != nil {
-			t.Errorf("could not get the signing root of test %d, value 2 %v", i, err)
-		}
-		// Check values have same result hash
-		if !bytes.Equal(output1[:], output2[:]) {
-			t.Errorf("test %d: hash mismatch: %X\n != %X", i, output1, output2)
+		if test.Err != nil {
+			if err == nil {
+				t.Fatalf("missing expected error of test %d value 1", i)
+			}
+			if test.Err.Error() != err.Error() {
+				t.Fatalf("incorrect error at test %d value 1 %v", i, err)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("could not get the signing root of test %d, value 1 %v", i, err)
+			}
+
+			output2, err := SigningRoot(test.Val2)
+			if err != nil {
+				t.Errorf("could not get the signing root of test %d, value 2 %v", i, err)
+			}
+			// Check values have same result hash
+			if !bytes.Equal(output1[:], output2[:]) {
+				t.Errorf("test %d: hash mismatch: %X\n != %X", i, output1, output2)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Added some tests to increase coverage of invalid scenarios.

Catch a panic on invalid input for SigningRoot; fix typo in a couple of errors.