### PR TITLE
Throw Error in SigningRoot if last field is not Signature #76

### DIFF
--- a/ssz.go
+++ b/ssz.go
@@ -178,6 +178,9 @@ func SigningRoot(val interface{}) ([32]byte, error) {
 			}
 			totalFields++
 		}
+		if elemType.Field(elemType.NumField()-1).Name != "Signature" {
+			return [32]byte{}, errors.New("last field has to be signature")
+		}
 		return types.StructFactory.FieldsHasher(elem, elemType, totalFields-1)
 	}
 	totalFields := 0

--- a/ssz_test.go
+++ b/ssz_test.go
@@ -22,6 +22,11 @@ type truncateSignatureCase struct {
 	Signature         []byte
 }
 
+type truncateWithoutSignatureCase struct {
+	Slot              uint64
+	PreviousBlockRoot []byte
+}
+
 type simpleNonProtoMessage struct {
 	Foo []byte
 	Bar uint64
@@ -494,6 +499,11 @@ func TestSigningRoot(t *testing.T) {
 			Val1: nil,
 			Err:  errors.New("value cannot be nil"),
 			Val2: nil,
+		},
+		{
+			Val1: &truncateWithoutSignatureCase{Slot: 20},
+			Err:  errors.New("last field has to be signature"),
+			Val2: &truncateWithoutSignatureCase{Slot: 20},
 		},
 	}
 


### PR DESCRIPTION
Fixes #76 

throw the error `last field has to be signature` fi last field is not Signature
Also, testing with a new structure named `truncateWithoutSignatureCase` which has no field name `Signature`.